### PR TITLE
Add fixes to automate-tests-with-guard.md

### DIFF
--- a/codecabulary/learn-test-driven-development/rspec/automate-tests-with-guard.md
+++ b/codecabulary/learn-test-driven-development/rspec/automate-tests-with-guard.md
@@ -4,7 +4,7 @@
 
 Guard is a command line tool that watches a file structure and automates events when changes are made in those files. While Guard has many uses, this article explores how we can use RSpec and Guard together to automate tests.
 
-#### Installing Guard 
+#### Installing Guard
 
 Once you have RSpec setup in your Rails project, you're ready to add Guard.
 
@@ -15,7 +15,7 @@ Once you have RSpec setup in your Rails project, you're ready to add Guard.
 			gem 'capybara'
 			gem 'guard-rspec'
 		end
-		
+
 2) Add other :test group gems
 
 		group :test do
@@ -25,14 +25,13 @@ Once you have RSpec setup in your Rails project, you're ready to add Guard.
 
 3) `bundle`
 
-4) `bundle exec guard init spec`
+4) `guard init spec`
 
-5) Edit the Guardfile to add:
+5) To run:
 
-		require 'active_support/core_ext'
-		
-		guard 'spec, :all_after_pass => false do
-		
-6) To run:
+		`bundle exec guard`
 
-		bundle exec guard
+6) To exit:
+
+		`exit`
+


### PR DESCRIPTION
Hi, 
I ran into some problems when following the tutorial "Automate Tests with Guard":

4) `bundle exec guard init spec`

My notes: When I ran Item 4, I got ERROR - Could not load 'guard/spec' or '~/.guard/templates/spec' or find class Guard::Spec. I was able to get past this step by running `guard init spec`

5) Edit the Guardfile to add:
    require 'active_support/core_ext'
    guard 'spec, :all_after_pass => false do

My notes: Item 5 seems to be an incomplete code fragment. I ran into errors when I added this to Guardfile.
I skipped this step and ran `bundle exec guard` without any problems.

I rewrote the file to modify step 4, delete step 5 and add step 6 (exiting Guard; Ctrl-C does not seem to do the trick).

Below are the references I used:
https://github.com/guard/guard
https://github.com/guard/guard-rspec

Thanks,
Beth
